### PR TITLE
Add missing https:// prefix for IRL GitLab link

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,5 +74,5 @@ To log into these GitLabs, one needs a LDAP/AD login with the DFKI.
 
 ## Private GitLabs
 
--   [IRL GitLab](irl-git.dfki.de)
+-   [IRL GitLab](https://irl-git.dfki.de/)
 -   [UMTL GitLab](https://umtl-git.dfki.de/)


### PR DESCRIPTION
Without the `https://` protocol prefix, GitHub treats this as a relative path, resulting in the link `https://github.com/Bengt/Awesome-DFKI/blob/main/irl-git.dfki.de`